### PR TITLE
Fixed System.NullReferenceException

### DIFF
--- a/Source/Tx.Windows/PerfCounters/PerfCounterRealTimeProbe.cs
+++ b/Source/Tx.Windows/PerfCounters/PerfCounterRealTimeProbe.cs
@@ -55,7 +55,10 @@ namespace Tx.Windows
 
         public override void Dispose()
         {
-            _timer.Dispose();
+            if (_timer != null)
+            {
+                _timer.Dispose();
+            }
 
             base.Dispose();
         }


### PR DESCRIPTION
A System.NullReferenceException occurs when the finalizer calls Dispose
on PerfCounterRealTimeProbe and the counterPaths are not valid.

Fix #23