### PR TITLE
Added ReadStream method so a PCAP stream can be read from anywhere; not requiring a file.

### DIFF
--- a/Source/Tx.Network/Pcap/Pcap.cs
+++ b/Source/Tx.Network/Pcap/Pcap.cs
@@ -15,7 +15,8 @@ namespace Tx.Network
         {
             using (var stream = File.OpenRead(filename))
             {
-                return ReadStream(stream);
+                foreach (var r in ReadStream(stream))
+                    yield return r;
             }
         }
 

--- a/Source/Tx.Network/Pcap/Pcap.cs
+++ b/Source/Tx.Network/Pcap/Pcap.cs
@@ -11,6 +11,11 @@ namespace Tx.Network
 {
     public class Pcap
     {
+        /// <summary>
+        /// Reads a file and returns the parsed <see cref="PcapRecord"/>s.
+        /// </summary>
+        /// <param name="filename">The name of the file to parse.</param>
+        /// <returns>The parsed <see cref="PcapRecord"/>s.</returns>
         public static IEnumerable<PcapRecord> ReadFile(string filename)
         {
             using (var stream = File.OpenRead(filename))
@@ -20,8 +25,16 @@ namespace Tx.Network
             }
         }
 
+        /// <summary>
+        /// Reads a <see cref="Stream"/> and returns the parsed <see cref="PcapRecord"/>s.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to parse.</param>
+        /// <returns>The parsed <see cref="PcapRecord"/>s.</returns>
         public static IEnumerable<PcapRecord> ReadStream(Stream stream)
         {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
             using (var reader = new BinaryReader(stream))
             {
                 int pos = 0;


### PR DESCRIPTION
The `ReadFile()` method now calls `ReadStream()` which contains the implementation that was previously housed in `ReadFile()`. This change simply adds a `ReadStream()` that `ReadFile()` calls into even though the diff, on first glance, may give the impression of more rigorous changes.