### PR TITLE
Making syslogs lighter by removing the custom parser support

### DIFF
--- a/Source/Tx.Network/Syslogs/Syslog.cs
+++ b/Source/Tx.Network/Syslogs/Syslog.cs
@@ -1,7 +1,6 @@
 ﻿namespace Tx.Network.Syslogs
 {
     using System;
-    using System.Collections.Generic;
     using System.Text;
 
     /// <summary>
@@ -33,12 +32,7 @@
         /// Facility of the Syslog provided from the PRIVAL field.
         /// </summary>
         public Facility LogFacility { get; private set; }
-
-        /// <summary>
-        /// Collection of regular expression matches.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> NamedCollectedMatches { get; private set; }
-
+        
         /// <summary>
         /// Creates a default instance of the Log object.
         /// </summary>
@@ -47,33 +41,22 @@
             string sourceIpAddress,
             Severity severity,
             Facility facility,
-            string message,
-            IReadOnlyDictionary<string, string> namedCollectedMatches)
+            string message)
         {
             this.ReceivedTime = receivedTime;
             this.SourceIpAddress = sourceIpAddress;
             this.LogSeverity = severity;
             this.LogFacility = facility;
             this.Message = message;
-            this.NamedCollectedMatches = namedCollectedMatches;
+            
         }
 
         public override string ToString()
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine();
-
-            if (this.NamedCollectedMatches != null)
-            {
-                foreach (var c in this.NamedCollectedMatches)
-                {
-                    sb.AppendFormat(c.Key).Append(", ");
-                    sb.AppendLine(c.Value);
-                    sb.AppendLine();
-                }
-            }
-
+            sb.AppendFormat("Received Time: {0}; Source IP: {1}; Severity: {2}; Facility: {3}; Message: {4}", ReceivedTime, SourceIpAddress, LogSeverity, LogFacility, Message);
+            
             return sb.ToString();
         }
     }

--- a/Source/Tx.Network/Syslogs/SyslogListener.cs
+++ b/Source/Tx.Network/Syslogs/SyslogListener.cs
@@ -6,8 +6,6 @@
 
     public class SyslogListener : BaseUdpReceiver<IEnvelope>
     {
-        private readonly SyslogParser syslogParser = new SyslogParser();
-
         public SyslogListener(IPEndPoint listenEndPoint, uint concurrentReceivers)
             : base(listenEndPoint, concurrentReceivers)
         {
@@ -32,7 +30,7 @@
 
                 try
                 {
-                    syslog = this.syslogParser.Parse(
+                    syslog = SyslogParser.Parse(
                         upacket.UdpData, 
                         upacket.ReceivedTime, 
                         upacket.PacketHeader.SourceIpAddress.ToString());

--- a/Source/Tx.Network/Syslogs/SyslogParser.cs
+++ b/Source/Tx.Network/Syslogs/SyslogParser.cs
@@ -1,47 +1,22 @@
 namespace Tx.Network.Syslogs
 {
     using System;
-    using System.Collections.Generic;
     using System.Text;
     using System.Text.RegularExpressions;
     using Tx.Network;
 
-    public class SyslogParser
+    public static class SyslogParser
     {
         public static readonly Regex DefaultParser = new Regex(
             @"\<(?<PRIVAL>\d+?)\>\s*(?<MESSAGE>.+)",
             RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
-        private readonly Regex parser;
-
-        private readonly string[] groupNames;
-
-        private readonly bool usingOnlyDefaultParser;
-
-        public SyslogParser()
-            : this(DefaultParser)
+        public static Syslog Parse(IUdpDatagram receivedPacket)
         {
-            this.usingOnlyDefaultParser = true;
+            return Parse(receivedPacket.Data.AsByteArraySegment(), receivedPacket.ReceivedTime, receivedPacket.PacketHeader.SourceIpAddress.ToString());
         }
 
-        public SyslogParser(Regex parser)
-        {
-            if (parser == null)
-            {
-                throw new ArgumentNullException("parser");
-            }
-
-            this.parser = parser;
-            this.groupNames = parser.GetGroupNames();
-            
-        }
-
-        public Syslog Parse(IUdpDatagram receivedPacket)
-        {
-            return this.Parse(receivedPacket.Data.AsByteArraySegment(), receivedPacket.ReceivedTime, receivedPacket.PacketHeader.SourceIpAddress.ToString());
-        }
-
-        public Syslog Parse(ArraySegment<byte> segment, DateTimeOffset receivedTime, string sourceIpAddress)
+        public static Syslog Parse(ArraySegment<byte> segment, DateTimeOffset receivedTime, string sourceIpAddress)
         {
             if (segment.Array == null)
             {
@@ -55,10 +30,8 @@ namespace Tx.Network.Syslogs
                 throw new ArgumentException("Incoming UDP datagram contained no Syslog data.");
             }
             
-
             var defMatch = DefaultParser.Match(logMessage);
-
-
+            
             if (!defMatch.Success)
             {
                 throw new ArgumentException("Cannot parse the incoming UDP datagram.");
@@ -78,33 +51,11 @@ namespace Tx.Network.Syslogs
             }
 
             var prival = int.Parse(privalMatch);
-            var severity = (Severity)Enum.ToObject(typeof(Severity), prival & 0x7);
-            var facility = (Facility)Enum.ToObject(typeof(Facility), prival >> 3);
+            var severity = (Severity)(prival & 0x7);
+            var facility = (Facility)(prival >> 3);
             var message = defMatch.Groups["MESSAGE"].Value.Trim();
-
-            Match customMatch;
-            if (this.usingOnlyDefaultParser)
-            {
-                customMatch = defMatch;
-            }
-            else
-            {
-                customMatch = this.parser.Match(logMessage);
-            }
-
-            var matches = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var groupName in this.groupNames)
-            {
-                var group = customMatch.Groups[groupName];
-
-                if (group.Success && !string.IsNullOrEmpty(group.Value))
-                {
-                    matches[groupName] = group.Value;
-                }
-            }
-
-            return new Syslog(receivedTime, sourceIpAddress, severity, facility, message, matches);
+            
+            return new Syslog(receivedTime, sourceIpAddress, severity, facility, message);
         }
     }
 }

--- a/Source/Tx.Network/Udp/BaseUdpReceiver.cs
+++ b/Source/Tx.Network/Udp/BaseUdpReceiver.cs
@@ -107,7 +107,7 @@ namespace Tx.Network
             if (!this.disposeCalled)
             {
                 this.GetDataProcessorAndReceive(); //call a new processor
-                //var packet = new IP(socketArgs.Buffer);
+                
                 T packet;
                 var ipPacket = PacketParser.Parse(DateTimeOffset.UtcNow, false, socketArgs.Buffer, 0, socketArgs.Buffer.Length);
 


### PR DESCRIPTION
Custom parser for syslog was kludgy and realistically custom parsing and enrichment is easier to do downstream. 