### PR TITLE
fix issue #50 PerfCounterReader.cs handle status PdhStatus.PDH_CSTATUS_NO_INSTANCE

### DIFF
--- a/Source/Tx.Windows/PerfCounters/PerfCounterReader.cs
+++ b/Source/Tx.Windows/PerfCounters/PerfCounterReader.cs
@@ -76,7 +76,7 @@ namespace Tx.Windows
         {
             PdhCounterHandle counter;
             PdhStatus status = PdhNativeMethods.PdhAddCounter(_query, counterPath, IntPtr.Zero, out counter);
-            if (status == PdhStatus.PDH_ENTRY_NOT_IN_LOG_FILE)
+            if (status == PdhStatus.PDH_ENTRY_NOT_IN_LOG_FILE || status == PdhStatus.PDH_CSTATUS_NO_INSTANCE)
                 return;
 
             PdhUtils.CheckStatus(status, PdhStatus.PDH_CSTATUS_VALID_DATA);


### PR DESCRIPTION
fix issue #50 PerfCounterReader.cs handle status PdhStatus.PDH_CSTATUS_NO_INSTANCE
before fix exception is thrown and playback.Run() exits without ability to handle

protected void AddCounter(string counterPath, int index)
        {
            PdhCounterHandle counter;
            PdhStatus status = PdhNativeMethods.PdhAddCounter(_query, counterPath, IntPtr.Zero, out counter);
            if (status == PdhStatus.PDH_ENTRY_NOT_IN_LOG_FILE || status == PdhStatus.PDH_CSTATUS_NO_INSTANCE)
                return;
