### PR TITLE
fix issue #53 update build.cmd NETSDK1004: Assets file dotnet restore

### DIFF
--- a/Source/Build.cmd
+++ b/Source/Build.cmd
@@ -6,6 +6,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Too
 
 REM Restore dependencies; there is some nuance here which we will get to later
 REM dotnet build /p:Configuration=Release /p:Platform=x64 "%~dp0TxKql.sln"
+dotnet restore
 msbuild "%~dp0Tx.sln"
 
 if "%ERRORLEVEL%" neq "0" (


### PR DESCRIPTION
fix issue #53 appveyor build fail in build.cmd
add dotnet restore before msbuild in build.cmd

https://ci.appveyor.com/project/jagilber/tx/builds/22789697
https://ci.appveyor.com/api/buildjobs/wc6mtmc7n5iokig8/log

