### PR TITLE
Handle "array bounds are invalid" exception.

### DIFF
--- a/Source/Tx.Windows.Logs/EventLogReaderExceptions.cs
+++ b/Source/Tx.Windows.Logs/EventLogReaderExceptions.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Tx.Windows
+{
+    public static class EventLogReaderExceptions
+    {
+        public static string ArrayBoundsInvalid = "The array bounds are invalid";
+    }
+}


### PR DESCRIPTION
There is an acceptable limit to the event size. Per batch, by default, the reader reads 64 events. If event size > acceptable limit, the reader throws "Array bounds are invalid". To fix this, the batch size needs to be reduced. This could have some performance impact, but the log is readable and not written off as corrupt.